### PR TITLE
Updating the Image.php Exif attempt

### DIFF
--- a/Component/Product/Image.php
+++ b/Component/Product/Image.php
@@ -133,7 +133,14 @@ class Image
 
     private function isValidImage($file)
     {
-        return exif_imagetype($file);
+        if (!function_exists( 'exif_imagetype') && 
+           (list($width, $height, $type, $attr) = getimagesize($file)) !== false ) {
+            return $type;
+        } elseif (filesize($file) > 11) {
+            return exif_imagetype($file);
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Exif_imagetype can only work if there are enough bits to read the file information. An example is trying to download the http://placehold.it/250x250 the download image type is undefined and locks the product import.